### PR TITLE
Adding include directives to allow for a user to never touch the library

### DIFF
--- a/BETA - SocketIOClient.h
+++ b/BETA - SocketIOClient.h
@@ -36,9 +36,19 @@
 #include "Arduino.h"
 
 //Uncomment the correct line
-//#include <Ethernet.h>					//For W5100
-//#include <UIPEthernet.h>				//For ENC28J60
+
+#ifdef W5100
+#include <Ethernet.h>					//For W5100
+#endif
+
+#ifdef ENC28J60
+#include <UIPEthernet.h>				//For ENC28J60
+#endif
+
+#ifdef ESP8266
 #include <ESP8266WiFi.h>				//For ESP8266
+#endif
+
 //#include "SPI.h"
 // Length of static data buffers
 #define DATA_BUFFER_LEN 120

--- a/BETA - SocketIOClient.h
+++ b/BETA - SocketIOClient.h
@@ -49,6 +49,11 @@
 #include <ESP8266WiFi.h>				//For ESP8266
 #endif
 
+#ifndef W5100 || ENC28J60 || ESP8266	//If no interface is defined
+#error "Please specify an interface such as W5100, ENC28J60, or ESP8266"
+#error "above your includes like so : #define <interface> "
+#endif
+
 //#include "SPI.h"
 // Length of static data buffers
 #define DATA_BUFFER_LEN 120

--- a/BETA - SocketIOClient.h
+++ b/BETA - SocketIOClient.h
@@ -51,7 +51,7 @@
 
 #ifndef W5100 || ENC28J60 || ESP8266	//If no interface is defined
 #error "Please specify an interface such as W5100, ENC28J60, or ESP8266"
-#error "above your includes like so : #define <interface> "
+#error "above your includes like so : #define ESP8266 "
 #endif
 
 //#include "SPI.h"

--- a/SocketIOClient.h
+++ b/SocketIOClient.h
@@ -35,10 +35,23 @@
 */
 #include "Arduino.h"
 
-//Uncomment the correct line
-//#include <Ethernet.h>					//For W5100
-//#include <UIPEthernet.h>				//For ENC28J60
+#ifdef W5100
+#include <Ethernet.h>					//For W5100
+#endif
+
+#ifdef ENC28J60
+#include <UIPEthernet.h>				//For ENC28J60
+#endif
+
+#ifdef ESP8266
 #include <ESP8266WiFi.h>				//For ESP8266
+#endif
+
+#ifndef W5100 || ENC28J60 || ESP8266	//If no interface is defined
+#error "Please specify an interface such as W5100, ENC28J60, or ESP8266"
+#error "above your includes like so : #define ESP8266 "
+#endif
+
 //#include "SPI.h"
 // Length of static data buffers
 #define DATA_BUFFER_LEN 120


### PR DESCRIPTION
It is much more user-friendly for the end developer to have a simple #define interface to this file to set it up in their application rather than having them edit the main header file.  

Using this interface is very simple, if they are using the ESP8266 their setup would look like:
```
    #define ESP8266
    #include "SocketIOClient.h"
```

or for the W5100
```
    #define W5100
    #include "SocketIOClient.h"
```

and lastly the ENC28J60
```
    #define ENC28J60
    #include "SocketIOClient.h"
```

Should the user not define any of these, the compilation will fail with an error reminding them that they need to define this in their file which is much more straight forward than having to hunt the libraries header file down and editing that.  It also address a degree of confidence that they know what they're doing. 

Now for you, the library developer, should you support more interfaces in the future, all you need to do is add : 
```
    #ifdef <new interface>
    #include <new interface.h>
    #endif 
```

and then you also need to append the new interfaces definition onto the `#ifndef` above the `#error` definitions like so:
```
    #ifndef W5100 || ENC28J60 || ESP8266 || <your new interface>
    #error etc.....
    #endif
```

Hope this helps! 
