### PR TITLE
Add ability to use query param when connecting to socket.io server.

### DIFF
--- a/SocketIOClient.cpp
+++ b/SocketIOClient.cpp
@@ -33,11 +33,12 @@ String Rcontent = "";
 
 
 
-bool SocketIOClient::connect(char thehostname[], int theport) {
+bool SocketIOClient::connect(char thehostname[], int theport, char thequery[] = "") {
 	if (!client.connect(thehostname, theport)) return false;
 	hostname = thehostname;
 	port = theport;
-	sendHandshake(hostname);
+	query = thequery;
+	sendHandshake(hostname, query);
 	return readHandshake();
 }
 
@@ -48,12 +49,13 @@ bool SocketIOClient::connectHTTP(char thehostname[], int theport) {
 	return true;
 }
 
-bool SocketIOClient::reconnect(char thehostname[], int theport)
+bool SocketIOClient::reconnect(char thehostname[], int theport, char thequery[] = "")
 {
 	if (!client.connect(thehostname, theport)) return false;
 	hostname = thehostname;
 	port = theport;
-	sendHandshake(hostname);
+	query = thequery;
+	sendHandshake(hostname, query);
 	return readHandshake();
 }
 
@@ -162,8 +164,10 @@ bool SocketIOClient::monitor() {
 	}
 }
 
-void SocketIOClient::sendHandshake(char hostname[]) {
-	client.println(F("GET /socket.io/1/?transport=polling&b64=true HTTP/1.1"));
+void SocketIOClient::sendHandshake(char hostname[], char query[] = "") {
+	client.print(F("GET /socket.io/1/?"));
+	client.print(query);
+	client.println(F("&transport=polling&b64=true HTTP/1.1"));
 	client.print(F("Host: "));
 	client.println(hostname);
 	client.println(F("Origin: Arduino\r\n"));

--- a/SocketIOClient.cpp
+++ b/SocketIOClient.cpp
@@ -224,7 +224,9 @@ bool SocketIOClient::readHandshake() {
 	}
 	Serial.println(F("Connecting via Websocket"));
 
-	client.print(F("GET /socket.io/1/websocket/?transport=websocket&b64=true&sid="));
+	client.print(F("GET /socket.io/1/websocket/?"));
+	client.print(query);
+	client.print(F("&transport=websocket&b64=true&sid="));
 	client.print(sid);
 	client.print(F(" HTTP/1.1\r\n"));
 

--- a/SocketIOClient.h
+++ b/SocketIOClient.h
@@ -45,11 +45,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 class SocketIOClient {
 public:
-	bool connect(char hostname[], int port = 80);
+	bool connect(char hostname[], int port = 80, char query[] = "");
 	bool connectHTTP(char hostname[], int port = 80);
 	bool connected();
 	void disconnect();
-	bool reconnect(char hostname[], int port = 80);
+	bool reconnect(char hostname[], int port = 80, char query[] = "");
 	bool monitor();
 	void sendMessage(String message = "");
 	void send(String RID, String Rname, String Rcontent);
@@ -63,7 +63,7 @@ public:
 	void deleteREST(String path);
 private:
 	void parser(int index);
-	void sendHandshake(char hostname[]);
+	void sendHandshake(char hostname[], char query[] = "");
 #if defined(W5100) || defined(ENC28J60)
 	EthernetClient client;				//For ENC28J60 or W5100
 #endif
@@ -78,6 +78,7 @@ private:
 	char sid[SID_LEN];
 	char key[28];
 	char *hostname;
+	char *query;
 	char *nsp;
 	int port;
 


### PR DESCRIPTION
Merge request to add ability to use query params when connecting to socket.io

I personally use it, but it also has been requested by issue #26 

To use it, simply add the query in a char array as per the hostname but url encode this string.

Example: 
```
char query[] = "id=foo&name=bar";
```
Then change your usage of connect() from `client.connect(hostname, port)` to `client.connect(hostname, port, query)`